### PR TITLE
Allow skipping the RPNG_NO_STDIO warning

### DIFF
--- a/src/rpng.h
+++ b/src/rpng.h
@@ -29,6 +29,8 @@
 *       #define RPNG_NO_STDIO
 *           Do not include FILE I/O API, only read/write from memory buffers
 *
+*       #define RPNG_NO_STDIO_WARNING
+*           Skips issuing a compiler warning when RPNG_NO_STDIO is defined.
 *
 *   DEPENDENCIES: libc (C standard library)
 *       stdlib.h        Required for: malloc(), calloc(), free()
@@ -1909,7 +1911,9 @@ static char *load_file_to_buffer(const char *filename, int *bytes_read)
     else RPNG_LOG("FILEIO: File path provided is not valid\n");
 #else
     (void)filename;
-    #warning No FILE I/O API, RPNG_NO_STDIO defined
+    #ifndef RPNG_NO_STDIO_WARNING
+        #warning No FILE I/O API, RPNG_NO_STDIO defined
+    #endif
 #endif
     return data;
 }
@@ -1939,7 +1943,9 @@ static void save_file_from_buffer(const char *filename, void *data, int bytesToW
     (void)filename;
     (void)data;
     (void)bytesToWrite;
-    #warning No FILE I/O API, RPNG_NO_STDIO defined
+    #ifndef RPNG_NO_STDIO_WARNING
+        #warning No FILE I/O API, RPNG_NO_STDIO defined
+    #endif
 #endif
 }
 


### PR DESCRIPTION
This change adds `RPNG_NO_STDIO_WARNING` to allow skipping the compiler warning about using `NO_STDIO`.